### PR TITLE
Resolved crash by fixing copy-paste mistake

### DIFF
--- a/engine-v2/src/game.cpp
+++ b/engine-v2/src/game.cpp
@@ -98,6 +98,11 @@ void GameUpdate(GameState* gs) {
 	if (IsKeyPressed(KEY_U)) {
 		remove("entity.txt");
 	}
+
+	// Debug
+	if (IsKeyPressed(KEY_BACKSPACE)) {
+		__debugbreak();
+	}
 }
 
 // This function is meant as a testbed for saving Entity data to a file so that
@@ -186,7 +191,7 @@ void ReadEntityFromFile(GameState* gs, std::string filename) {
 						file >> t.pos.x >> ignore_string >> t.pos.y;
 						int transform_index = gs->c_grid_transforms.size();
 						gs->c_grid_transforms.push_back(t);
-						e->transform = transform_index;
+						e->grid_transform = transform_index;
 						// ignore the "] ;"
 						file >> ignore_string >> ignore_string;
 					}


### PR DESCRIPTION
When creating the code for loading the grid_transform component, I had copy-pasted the code from the transform component. I missed adjusting all the variables and so the grid_transform index in the entities was not being written. Instead the transform index was being overwritten.

closes #19 