### PR TITLE
Add cRenderable

### DIFF
--- a/engine-v2/engine-v2.vcxproj
+++ b/engine-v2/engine-v2.vcxproj
@@ -176,6 +176,8 @@
     <ClInclude Include="src\game_state.h" />
     <ClInclude Include="src\grid_transform.h" />
     <ClInclude Include="src\items.h" />
+    <ClInclude Include="src\raylib_cpp_helpers.h" />
+    <ClInclude Include="src\renderable.h" />
     <ClInclude Include="src\units.h" />
     <ClInclude Include="src\universal.h" />
   </ItemGroup>
@@ -184,6 +186,8 @@
     <ClCompile Include="src\game.cpp" />
     <ClCompile Include="src\grid_transform.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\raylib_cpp_helpers.cpp" />
+    <ClCompile Include="src\renderable.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\raysan5\raylib.vcxproj">

--- a/engine-v2/engine-v2.vcxproj.filters
+++ b/engine-v2/engine-v2.vcxproj.filters
@@ -33,6 +33,12 @@
     <ClInclude Include="src\universal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\renderable.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\raylib_cpp_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\entity.cpp">
@@ -45,6 +51,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\main.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\renderable.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\raylib_cpp_helpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/engine-v2/src/entity.cpp
+++ b/engine-v2/src/entity.cpp
@@ -2,10 +2,10 @@
 
 std::string cTransform::ToString() {
 	std::string result = "";
-	result.append("component transform = [ ");
-	result.append(std::to_string(pos.x));
-	result.append(", ");
-	result.append(std::to_string(pos.y));
-	result.append(" ] ;");
+	result += "component transform = [ ";
+	result += std::to_string(pos.x);
+	result += ", ";
+	result += std::to_string(pos.y);
+	result += " ] ;";
 	return result;
 }

--- a/engine-v2/src/entity.h
+++ b/engine-v2/src/entity.h
@@ -9,23 +9,23 @@ struct cTransform {
 };
 
 struct Entity {
-	std::string name;
+	std::string name = "Unnamed";
 	int64_t id = -1;
 	bool is_active = false;
 
 	int32_t transform = -1;
 	int32_t grid_transform = -1;
+	int32_t renderable = -1;
 	int32_t citem = 1;
 
-	Entity() {
-		name = "unnamed";
-	}
+	Entity() = default;
 
-	Entity(std::string _name, int64_t _id, int32_t _transform, int32_t _grid_transform) {
+	Entity(std::string _name, int64_t _id, int32_t _transform, int32_t _grid_transform, int32_t _renderable) {
 		name = _name;
 		id = _id;
 		transform = _transform;
 		grid_transform = _grid_transform;
+		renderable = _renderable;
 	}
 };
 

--- a/engine-v2/src/game.cpp
+++ b/engine-v2/src/game.cpp
@@ -117,6 +117,7 @@ void WriteEntityToFile(GameState* gs) {
 		file << "\tis_active = " << e.is_active << " ;\n";
 		file << "\t" << gs->c_transforms[e.transform].ToString() << "\n";
 		file << "\t" << gs->c_grid_transforms[e.grid_transform].ToString() << "\n";
+		file << "\t" << gs->c_renderables[e.renderable].ToString() << "\n";
 		file << "];\n";
 	}
 
@@ -186,12 +187,24 @@ void ReadEntityFromFile(GameState* gs, std::string filename) {
 					else if (file_contents == "grid_transform") {
 						// ignore the "= ["
 						file >> ignore_string >> ignore_string;
-						// need to load the transform component
+						// need to load the grid_transform component
 						cGridTransform t;
 						file >> t.pos.x >> ignore_string >> t.pos.y;
 						int transform_index = gs->c_grid_transforms.size();
 						gs->c_grid_transforms.push_back(t);
 						e->grid_transform = transform_index;
+						// ignore the "] ;"
+						file >> ignore_string >> ignore_string;
+					}
+					else if (file_contents == "renderable") {
+						// ignore the "= ["
+						file >> ignore_string >> ignore_string;
+						// need to load the renderable component
+						cRenderable r;
+						file >> r.texture_handle >> ignore_string >> r.tint_color;
+						int renderable_index = gs->c_renderables.size();
+						gs->c_renderables.push_back(r);
+						e->renderable = renderable_index;
 						// ignore the "] ;"
 						file >> ignore_string >> ignore_string;
 					}

--- a/engine-v2/src/game_state.h
+++ b/engine-v2/src/game_state.h
@@ -3,6 +3,7 @@
 #include "universal.h"
 
 #include "grid_transform.h"
+#include "renderable.h"
 #include "entity.h"
 
 struct GameState {
@@ -13,11 +14,13 @@ struct GameState {
 	// Entities and Components
 	std::unordered_map<std::string, cTransform> blueprint_transforms;
 	std::unordered_map<std::string, cGridTransform> blueprint_grid_transforms;
+	std::unordered_map<std::string, cRenderable> blueprint_renderables;
 	
 	int64_t entity_id_counter = 0;
 	std::vector<Entity> entities;
 	std::vector<cTransform> c_transforms;
 	std::vector<cGridTransform> c_grid_transforms;
+	std::vector<cRenderable> c_renderables;
 
 	int32_t selected_entity = 0;
 

--- a/engine-v2/src/grid_transform.cpp
+++ b/engine-v2/src/grid_transform.cpp
@@ -2,10 +2,10 @@
 
 std::string cGridTransform::ToString() {
 	std::string result = "";
-	result.append("component grid_transform = [ ");
-	result.append(std::to_string(pos.x));
-	result.append(", ");
-	result.append(std::to_string(pos.y));
-	result.append(" ] ;");
+	result += "component grid_transform = [ ";
+	result += std::to_string(pos.x);
+	result += ", ";
+	result += std::to_string(pos.y);
+	result += " ] ;";
 	return result;
 }

--- a/engine-v2/src/main.cpp
+++ b/engine-v2/src/main.cpp
@@ -13,6 +13,7 @@ static std::filesystem::path path_to_gui_styles = "assets/gui/style";
 static std::string bluish = "bluish";
 static std::string gui_layout_extension = ".rgl";
 static std::string gui_style_extension = ".rgs";
+static std::string texture_extension = ".png";
 
 static void Button000(GameState* gs);
 
@@ -52,7 +53,7 @@ void DrawGridLines(GameState& gs) {
 }
 
 void LoadTextureFromFile(GameState& gs, std::string filename) {
-	std::filesystem::path full_path = path_to_textures / std::filesystem::path(filename);
+	std::filesystem::path full_path = path_to_textures / std::filesystem::path(filename + texture_extension);
 	size_t index = gs.textures.size();
 	gs.texture_handles.insert({ full_path.filename().stem().string().c_str(), index });
 	gs.textures.push_back(LoadTexture(full_path.string().c_str()));
@@ -104,10 +105,14 @@ int main(void) {
 	// Load Texture Assets
 	//----------------------------------------------------------------------------------
 
+	// Load a pure magenta texture to act as the debug texture in slot 0.
+	gs.texture_handles.insert({ "Debug", 0 });
+	gs.textures.push_back(LoadTextureFromImage(GenImageColor(10, 10, MAGENTA)));
+	
 	// std::string tex_name = "Tex0.png";
 	// This will load "assets/gfx/Tex0.png"
 	// LoadTextureFromFile(gs, tex_name);
-	
+
 	//----------------------------------------------------------------------------------
 	
 	while (!WindowShouldClose()) {
@@ -125,7 +130,7 @@ int main(void) {
 		DrawText("This is the game window", 190, 200, 20, LIGHTGRAY);
 
 		for (Entity& e : gs.entities) {
-			DrawRectangle(gs.c_transforms[e.transform].pos.x, gs.c_transforms[e.transform].pos.y, gs.entity_scale, gs.entity_scale, BLUE);
+			DrawTextureEx(gs.textures[gs.c_renderables[e.renderable].texture_handle], gs.c_transforms[e.transform].pos, 0.0f, 1.0f, gs.c_renderables[e.renderable].tint_color);
 		}
 
 		EndMode2D();
@@ -220,12 +225,17 @@ static void Button000(GameState* gs) {
 	size_t i_g_t = gs->c_grid_transforms.size();
 	gs->c_grid_transforms.push_back(gt);
 
+	cRenderable r;
+	size_t i_r = gs->c_renderables.size();
+	gs->c_renderables.push_back(r);
+
 	Entity e = {};
 	e.id = gs->entity_id_counter++;
 	e.is_active = true;
 	e.name = "Box";
 	e.transform = i_t;
 	e.grid_transform = i_g_t;
+	e.renderable = i_r;
 
 	gs->entities.push_back(e);
 }

--- a/engine-v2/src/raylib_cpp_helpers.cpp
+++ b/engine-v2/src/raylib_cpp_helpers.cpp
@@ -1,0 +1,12 @@
+#include "raylib_cpp_helpers.h"
+
+std::istream& operator>>(std::istream& input, Color& c) {
+    int r, g, b, a;
+    std::string ignore;
+    input >> r >> ignore >> g >> ignore >> b >> ignore >> a;
+    c.r = (unsigned char)r;
+    c.g = (unsigned char)g;
+    c.b = (unsigned char)b;
+    c.a = (unsigned char)a;
+    return input;
+}

--- a/engine-v2/src/raylib_cpp_helpers.h
+++ b/engine-v2/src/raylib_cpp_helpers.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "universal.h"
+
+std::istream& operator>>(std::istream& input, Color& c);

--- a/engine-v2/src/renderable.cpp
+++ b/engine-v2/src/renderable.cpp
@@ -1,0 +1,17 @@
+#include "renderable.h"
+
+std::string cRenderable::ToString() {
+	std::string result = "";
+	result += "component renderable = [ ";
+	result += std::to_string(texture_handle);
+	result += ", ";
+	result += std::to_string(tint_color.r);
+	result += ", ";
+	result += std::to_string(tint_color.g);
+	result += ", ";
+	result += std::to_string(tint_color.b);
+	result += ", ";
+	result += std::to_string(tint_color.a);
+	result += " ] ;";
+	return result;
+}

--- a/engine-v2/src/renderable.h
+++ b/engine-v2/src/renderable.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "universal.h"
+
+struct cRenderable {
+	size_t texture_handle = 0;
+	Color tint_color = WHITE;
+
+	cRenderable() = default;
+
+	std::string ToString();
+};

--- a/engine-v2/src/universal.h
+++ b/engine-v2/src/universal.h
@@ -11,3 +11,5 @@
 #include "raylib.h"
 
 #include "IVector2.h"
+
+#include "raylib_cpp_helpers.h"


### PR DESCRIPTION
closes #23 Adds `cRenderable` and necessary functionality in game.cpp and main.cpp to use it for drawing entities. Also added a helper file for making Raylib work nicely with CPP.