### PR TITLE
Implemented the Entity Manager

### DIFF
--- a/engine-v2/engine-v2.vcxproj
+++ b/engine-v2/engine-v2.vcxproj
@@ -171,6 +171,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="src\components.h" />
+    <ClInclude Include="src\entity_manager.h" />
     <ClInclude Include="src\IVector2.h" />
     <ClInclude Include="src\entity.h" />
     <ClInclude Include="src\game.h" />
@@ -182,6 +183,7 @@
   <ItemGroup>
     <ClCompile Include="src\components.cpp" />
     <ClCompile Include="src\entity.cpp" />
+    <ClCompile Include="src\entity_manager.cpp" />
     <ClCompile Include="src\game.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\raygui_helpers.cpp" />

--- a/engine-v2/engine-v2.vcxproj.filters
+++ b/engine-v2/engine-v2.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="src\raygui_helpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\entity_manager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\entity.cpp">
@@ -51,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\raygui_helpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\entity_manager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/engine-v2/src/entity.h
+++ b/engine-v2/src/entity.h
@@ -2,6 +2,24 @@
 
 #include "universal.h"
 
+#include "components.h"
+
+struct EntityContext {
+	bool is_active = false;
+	int32_t id = -1;
+	std::string name;
+
+	bool renderable = false;
+	int texture_scale = 0;
+	size_t texture_handle = 0;
+	Color tint_color = WHITE;
+
+	bool grid_transform = false;
+	IVector2 gt_pos = { 0, 0 };
+
+	bool unit = false;
+};
+
 struct Entity {
 	std::string name = "Unnamed";
 	int64_t id = -1;

--- a/engine-v2/src/entity_manager.cpp
+++ b/engine-v2/src/entity_manager.cpp
@@ -1,0 +1,76 @@
+#include "entity_manager.h"
+
+// Component Accessor functions
+
+cGridTransform& EntityManager::GridTransform(Entity& e) {
+	return c_grid_transforms[e.grid_transform];
+}
+
+cRenderable& EntityManager::Renderable(Entity& e) {
+	return c_renderables[e.renderable];
+}
+
+cUnit& EntityManager::Unit(Entity& e) {
+	return c_units[e.unit];
+}
+
+// Add Component functions
+
+int32_t EntityManager::AddGridTransform(cGridTransform& gt) {
+	int32_t index = c_grid_transforms.size();
+	c_grid_transforms.push_back(gt);
+	return index;
+}
+
+int32_t EntityManager::AddRenderable(cRenderable& r) {
+	int32_t index = c_renderables.size();
+	c_renderables.push_back(r);
+	return index;
+}
+
+int32_t EntityManager::AddUnit(cUnit& u) {
+	int32_t index = c_units.size();
+	c_units.push_back(u);
+	return index;
+}
+
+// Entity Management functions
+
+void EntityManager::CreateEntity(EntityContext& ec) {
+	Entity e = {};
+
+	if (ec.grid_transform) {
+		cGridTransform gt;
+		gt.pos = ec.gt_pos;
+		e.grid_transform = AddGridTransform(gt);
+	}
+
+	if (ec.renderable) {
+		Vector2 pos = { 0, 0 };
+		if (e.grid_transform >= 0) {
+			pos.x = (float)(GridTransform(e).pos.x * ec.texture_scale);
+			pos.y = (float)(GridTransform(e).pos.y * ec.texture_scale);
+		}
+		cRenderable r = { pos, ec.texture_handle, ec.tint_color };
+		e.renderable = AddRenderable(r);
+	}
+
+	if (ec.unit) {
+		cUnit u;
+		e.unit = AddUnit(u);
+	}
+
+	// If the id is known and in the context use it
+	// Otherwise, we want to generate a new id.
+	if (ec.id >= 0) {
+		e.id = ec.id;
+	}
+	else {
+		e.id = entity_id_counter++;
+	}
+
+	e.is_active = ec.is_active;
+	e.name = std::string(ec.name);
+
+	entities.push_back(e);
+}

--- a/engine-v2/src/entity_manager.h
+++ b/engine-v2/src/entity_manager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "universal.h"
+
+#include "components.h"
+#include "entity.h"
+
+struct EntityManager {
+	int64_t entity_id_counter = 0;
+	
+	std::vector<Entity> entities;
+	std::vector<cGridTransform> c_grid_transforms;
+	std::vector<cRenderable> c_renderables;
+	std::vector<cUnit> c_units;
+
+	// Component Accessors
+	cGridTransform& GridTransform(Entity& e);
+	cRenderable& Renderable(Entity& e);
+	cUnit& Unit(Entity& e);
+
+	// Add Component
+	int32_t AddGridTransform(cGridTransform& gt);
+	int32_t AddRenderable(cRenderable& r);
+	int32_t AddUnit(cUnit& u);
+	
+	// Entity Management
+	void CreateEntity(EntityContext& ec);
+};

--- a/engine-v2/src/game_state.h
+++ b/engine-v2/src/game_state.h
@@ -4,9 +4,11 @@
 
 #include "components.h"
 #include "entity.h"
+#include "entity_manager.h"
 
 struct GameState {
 	// Assets / Textures
+	int entity_scale = 32;
 	std::unordered_map<std::string, size_t> texture_handles;
 	std::vector<Texture2D> textures;
 
@@ -15,15 +17,9 @@ struct GameState {
 	std::unordered_map<std::string, cRenderable> blueprint_renderables;
 	std::unordered_map<std::string, cUnit> blueprint_units;
 	
-	int64_t entity_id_counter = 0;
-	std::vector<Entity> entities;
-	std::vector<cGridTransform> c_grid_transforms;
-	std::vector<cRenderable> c_renderables;
-	std::vector<cUnit> c_units;
+	EntityManager em;
 
 	int32_t selected_entity = 0;
-
-	int entity_scale = 32;
 
 	// Camera and UI Information ==============================================
 	Vector2 mouse_pos = {};


### PR DESCRIPTION
The initial goal of the `EntityManager` to automatically handle the case when trying to perform some functionality but the component doesn't exist for that entity was misguided and instead should be handled by the Systems of the ECS rather than the `EntityManager`. However, the `EntityManager` still provided benefits by reducing the amount of code used to access components and use them. It also made creating entities simpler. I removed the functions for the Spawn Entity and Spawn Random Entity GUI because the random entity version isn't needed any more and the functionality of the Spawn Entity button got moved entirely to the `EntityManager`'s `CreateEntity()` function.

closes #42 