### PR TITLE
Added Basic Unit movement + supporting changes

### DIFF
--- a/engine-v2/engine-v2.vcxproj
+++ b/engine-v2/engine-v2.vcxproj
@@ -176,6 +176,7 @@
     <ClInclude Include="src\entity.h" />
     <ClInclude Include="src\game.h" />
     <ClInclude Include="src\game_state.h" />
+    <ClInclude Include="src\movement.h" />
     <ClInclude Include="src\raygui_helpers.h" />
     <ClInclude Include="src\raylib_cpp_helpers.h" />
     <ClInclude Include="src\universal.h" />
@@ -186,6 +187,7 @@
     <ClCompile Include="src\entity_manager.cpp" />
     <ClCompile Include="src\game.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\movement.cpp" />
     <ClCompile Include="src\raygui_helpers.cpp" />
     <ClCompile Include="src\raylib_cpp_helpers.cpp" />
   </ItemGroup>

--- a/engine-v2/engine-v2.vcxproj.filters
+++ b/engine-v2/engine-v2.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="src\entity_manager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\movement.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\entity.cpp">
@@ -57,6 +60,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\entity_manager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\movement.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/engine-v2/src/components.h
+++ b/engine-v2/src/components.h
@@ -27,6 +27,8 @@ struct cRenderable {
 	a trading caravan, a fleet of ships, and a herd of animals.
 */
 struct cUnit {
+	int movement_points = 3;
+	int current_movement_points = movement_points;
 	bool waypoint_active = false; // is the movement waypoint active
 	std::deque<Vector2> waypoint_pos; // where the movement waypoint is
 	

--- a/engine-v2/src/entity_manager.cpp
+++ b/engine-v2/src/entity_manager.cpp
@@ -36,7 +36,7 @@ int32_t EntityManager::AddUnit(cUnit& u) {
 
 // Entity Management functions
 
-void EntityManager::CreateEntity(EntityContext& ec) {
+int EntityManager::CreateEntity(EntityContext& ec) {
 	Entity e = {};
 
 	if (ec.grid_transform) {
@@ -72,4 +72,5 @@ void EntityManager::CreateEntity(EntityContext& ec) {
 	e.name = std::string(ec.name);
 
 	entities.push_back(e);
+	return entities.size() - 1;
 }

--- a/engine-v2/src/entity_manager.h
+++ b/engine-v2/src/entity_manager.h
@@ -24,5 +24,5 @@ struct EntityManager {
 	int32_t AddUnit(cUnit& u);
 	
 	// Entity Management
-	void CreateEntity(EntityContext& ec);
+	int CreateEntity(EntityContext& ec);
 };

--- a/engine-v2/src/game.cpp
+++ b/engine-v2/src/game.cpp
@@ -91,6 +91,36 @@ void GameUpdate(GameState* gs) {
 				gs->em.GridTransform(e).pos.y += 1;
 			}
 
+			if (e.unit >= 0) {
+				if (IsKeyPressed(KEY_R)) {
+					gs->em.Unit(e).current_movement_points = gs->em.Unit(e).movement_points;
+				}
+
+				if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) {
+					Vector2 source = gs->em.GridTransform(e).pos;
+					Vector2 dest = gs->grid_pos;
+					int movement_points = gs->em.Unit(e).current_movement_points;
+					BuildPathContext bpc = BuildPath(source, dest, movement_points);
+					if (bpc.found_path) {
+						std::cout << "Found Path\n";
+						while (bpc.orders.size() > 0) {
+							int dir = bpc.orders.front();
+							bpc.orders.pop_front();
+							switch (dir) {
+								case 1: gs->em.GridTransform(e).pos.y -= 1.0f; std::cout << dir << "\n"; break;
+								case 2: gs->em.GridTransform(e).pos.y += 1.0f; std::cout << dir << "\n"; break;
+								case 3: gs->em.GridTransform(e).pos.x -= 1.0f; std::cout << dir << "\n"; break;
+								case 4: gs->em.GridTransform(e).pos.x += 1.0f; std::cout << dir << "\n"; break;
+							}
+						}
+						gs->em.Unit(e).current_movement_points = bpc.remaining_movement_points;
+					}
+					else {
+						std::cout << "Did not find path\n";
+					}
+				}
+			}
+
 			if (e.renderable >= 0) {
 				gs->em.Renderable(e).pos = gs->em.GridTransform(e).pos * gs->entity_scale;
 			}

--- a/engine-v2/src/game_state.h
+++ b/engine-v2/src/game_state.h
@@ -6,6 +6,8 @@
 #include "entity.h"
 #include "entity_manager.h"
 
+#include "movement.h"
+
 struct GameState {
 	// Assets / Textures
 	int entity_scale = 32;
@@ -19,7 +21,7 @@ struct GameState {
 	
 	EntityManager em;
 
-	int32_t selected_entity = 0;
+	int32_t selected_entity = -1;
 
 	// Camera and UI Information ==============================================
 	Vector2 mouse_pos = {};

--- a/engine-v2/src/main.cpp
+++ b/engine-v2/src/main.cpp
@@ -92,6 +92,10 @@ int main(void) {
 	label_num_entities.bounds = { anchor01.x + 10, anchor01.y + 90, 125, 25 };
 	label_num_entities.text = {};
 
+	gui::LabelContext label_unit_movement_points = {};
+	label_unit_movement_points.bounds = { anchor01.x + 10, anchor01.y + 110, 125, 25 };
+	label_unit_movement_points.text = {};
+
 	// Entity Spawner variables
 	//----------------------------------------------------------------------------------
 	Vector2 anchor_EntitySpawner = { anchor01.x + 10, 220 };
@@ -266,6 +270,13 @@ int main(void) {
 		label_num_entities.text += std::to_string(gs.em.entities.size());
 		gui::Label(label_num_entities);
 
+		label_unit_movement_points.text.clear();
+		label_unit_movement_points.text += "Current Movement Points: ";
+		if (gs.selected_entity >= 0) {
+			label_unit_movement_points.text += std::to_string(gs.em.c_units[gs.selected_entity].current_movement_points);
+		}
+		gui::Label(label_unit_movement_points);
+
 		// Entity Spawner
 		if (window_entity_spawner.is_active) {
 			gui::WindowBox(window_entity_spawner);
@@ -302,7 +313,7 @@ int main(void) {
 				ec.gt_pos = gt_pos;
 				ec.unit = checkbox_unit.checked;
 
-				gs.em.CreateEntity(ec);
+				gs.selected_entity = gs.em.CreateEntity(ec);
 			}
 
 			Vector2 texture_preview_pos = { color_picker_entity_spawner.bounds.x + color_picker_entity_spawner.bounds.width + 40, color_picker_entity_spawner.bounds.y };

--- a/engine-v2/src/movement.cpp
+++ b/engine-v2/src/movement.cpp
@@ -1,0 +1,54 @@
+#include "movement.h"
+
+int ManhattanDistance(Vector2 start, Vector2 end) {
+	return fabsf(end.x - start.x) + fabsf(end.y - start.y);
+}
+
+
+#define UP 1
+#define DOWN 2
+#define LEFT 3
+#define RIGHT 4
+BuildPathContext BuildPath(Vector2 start, Vector2 end, int movement_points) {
+	BuildPathContext bpc;
+	
+	int distance = ManhattanDistance(start, end);
+	if (distance > movement_points) {
+		bpc.found_path = false;
+		bpc.remaining_movement_points = movement_points;
+		return bpc;
+	}
+
+	Vector2 ghost = start;
+	while (ghost != end) {
+		Vector2 delta = end - ghost;
+		if (fabsf(delta.x) >= fabsf(delta.y)) {
+			if (delta.x >= 0) {
+				bpc.orders.push_back(RIGHT);
+				ghost.x += 1.0f;
+			}
+			else {
+				bpc.orders.push_back(LEFT);
+				ghost.x -= 1.0f;
+			}
+		}
+		else {
+			if (delta.y >= 0) {
+				bpc.orders.push_back(DOWN);
+				ghost.y += 1.0f;
+			}
+			else {
+				bpc.orders.push_back(UP);
+				ghost.y -= 1.0f;
+			}
+		}
+	}
+
+	bpc.found_path = true;
+	bpc.remaining_movement_points = movement_points - distance;
+	return bpc;
+}
+#undef UP
+#undef DOWN
+#undef LEFT
+#undef RIGHT

--- a/engine-v2/src/movement.h
+++ b/engine-v2/src/movement.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "universal.h"
+
+int ManhattanDistance(Vector2 start, Vector2 end);
+
+struct BuildPathContext {
+	bool found_path = false;
+	int remaining_movement_points = 0;
+	std::deque<int> orders;
+};
+
+BuildPathContext BuildPath(Vector2 start, Vector2 end, int movement_points);


### PR DESCRIPTION
Added basic hardcoded unit movement. No animations or transitions just getting things working. Properly follows range guideline set in the `BuildPath()` function. Added `movement_points` and `current_movement_points` to `cUnit` to use with `BuildPath()` to determine a unit's range. Added a display in the debug window of how many movement points are left. Movement is handled by selecting a unit and then right clicking on the map. R will reset the unit's movement_points to maximum. Modified `CreateEntity()` to return the index of the entity. This was used to improve behavior of the Spawn Entity button.

Implements some functionality of #17, #30, and #31